### PR TITLE
fix event tree join

### DIFF
--- a/src/event_tree.rs
+++ b/src/event_tree.rs
@@ -25,8 +25,9 @@ impl EventTree {
             {
                 r.join(l)
             }
-            (Leaf(a), SubTree(b, l, r)) | (SubTree(a, l, r), Leaf(b)) => {
-                SubTree(a, Box::new(l.lift(b - a)), Box::new(r.lift(b - a))).norm()
+            (Leaf(_), r @ SubTree(_, _, _)) => r,
+            (l @ SubTree(_, _, _), Leaf(b)) => {
+                l.join(SubTree(b, Box::new(Leaf(0)), Box::new(Leaf(0))))
             }
             (SubTree(a, l0, r0), SubTree(b, l1, r1)) => SubTree(
                 a,
@@ -330,6 +331,17 @@ mod tests {
 
         let e2 = e0.join(e1);
         assert_eq!(e2, SubTree(4, Box::new(Leaf(2)), Box::new(Leaf(0))));
+    }
+
+    #[test]
+    fn test_larger_leaf() {
+        use EventTree::*;
+
+        let e0 = SubTree(0, Box::new(Leaf(0)), Box::new(Leaf(1)));
+        let e1 = Leaf(1);
+
+        let e2 = e0.join(e1);
+        assert_eq!(e2, Leaf(1));
     }
 
     #[test]


### PR DESCRIPTION
Currently, joining the event trees `(0, 0, 1)` and `1` yields `(1, 0, 1)`; this does not match the behavior described in the paper or other implementations, which yield `1` (which is also the correct result, as the result from the current impl dominates more than it needs to and is thus not a true semilattice join).

Fixing this could be done without allocating boxes for 0-leaf-subtrees that immediately get dropped anyways, but would've required more complex code. I implemented this at what i believe the abstraction level matching the other rules.